### PR TITLE
Bugfix: Remove gaps in drawings

### DIFF
--- a/.addon
+++ b/.addon
@@ -3,6 +3,7 @@
   "Type": "game",
   "Org": "pmg",
   "Ident": "sketch",
+  "Tags": null,
   "Schema": 1,
   "HasAssets": true,
   "AssetsPath": "",


### PR DESCRIPTION
This commit addresses gaps in drawings that appear because of delays between drag events. Just adds interpolates between old/new points to smooth things out. See screenshots below for a before/after comparison.

### Before
![Gaps preview](https://i.imgur.com/rxZFBKT.png)

### After
![No gaps preview](https://i.imgur.com/iu5RCTv.png)